### PR TITLE
Updated PIP resource location

### DIFF
--- a/Hands-on lab/labfiles/sap-hana/templates/ubuntu_azurecli_vm_template.json
+++ b/Hands-on lab/labfiles/sap-hana/templates/ubuntu_azurecli_vm_template.json
@@ -70,7 +70,7 @@
             "type": "Microsoft.Network/publicIPAddresses",
             "apiVersion": "[variables('networkApiVersion')]",
             "name": "[variables('pipName')]",
-            "location": "eastus",
+            "location": "[resourceGroup().location]",
             "sku": {
                 "name": "Basic"
             },


### PR DESCRIPTION
The resource should not be provisioned in an explicitly designated location, or else it collides with the instructions, according to which the student can pick their favorite region. The PIP must be in the same region as the NIC.